### PR TITLE
Get game index before creating new game

### DIFF
--- a/assets/scripts/game/gameEvents.js
+++ b/assets/scripts/game/gameEvents.js
@@ -8,12 +8,12 @@ const store = require('../store')
 const onGameBoardCreate = () => {
   $('.game-space').on('click', onGameSpaceClick)
   store.currentPlayerIndex = 0
-  gameApi.gameBoardCreate()
-    .then(gameUi.onGameBoardCreateSuccess)
-    .catch(gameUi.onGameBoardCreateFailure)
   gameApi.gameIndex()
     .then(gameUi.onGetAllGamesSuccess)
     .catch(gameUi.onGetAllGamesFailure)
+  gameApi.gameBoardCreate()
+    .then(gameUi.onGameBoardCreateSuccess)
+    .catch(gameUi.onGameBoardCreateFailure)
 }
 
 const onGameSpaceClick = event => {


### PR DESCRIPTION
Game creation event now gets game history before creating new game
Current game should not count for game history display (even though it
does technically exist)