### PR TITLE
Refactor game event handlers

### DIFF
--- a/assets/scripts/game/gameApi.js
+++ b/assets/scripts/game/gameApi.js
@@ -14,7 +14,7 @@ const gameBoardCreate = () => {
   })
 }
 
-const gameSpaceClick = (gameSpaceIndex, winner) => {
+const gameSpaceClick = (gameSpaceIndex, currentPlayer, winner) => {
   const gameId = store.user.game.id
 
   return $.ajax({
@@ -27,7 +27,7 @@ const gameSpaceClick = (gameSpaceIndex, winner) => {
       'game': {
         'cell': {
           'index': gameSpaceIndex,
-          'value': store.players[store.currentPlayerIndex]
+          'value': currentPlayer
         },
         'over': Boolean(winner)
       }
@@ -36,12 +36,12 @@ const gameSpaceClick = (gameSpaceIndex, winner) => {
 }
 
 const gameIndex = (over) => {
-  let overQuery = ''
-  if (over !== undefined) {
-    overQuery = `?over=${over}`
-  }
   // Get all games associated with a user. Optional over parameter can be either
   // 'true' or 'false' to restrict results to games with matching over property
+  let overQuery = ''
+  if ([true, false].includes(over)) {
+    overQuery = `?over=${over}`
+  }
   return $.ajax({
     url: `${config.apiUrl}/games${overQuery}`,
     method: 'GET',

--- a/assets/scripts/game/gameEvents.js
+++ b/assets/scripts/game/gameEvents.js
@@ -7,7 +7,8 @@ const store = require('../store')
 
 const onGameBoardCreate = () => {
   $('.game-space').on('click', onGameSpaceClick)
-  store.currentPlayerIndex = 0
+  // Get list of previous games before creating the new one to avoid counting
+  // the newly created (uncompleted) game in the UI
   gameApi.gameIndex()
     .then(gameUi.onGetAllGamesSuccess)
     .catch(gameUi.onGetAllGamesFailure)
@@ -20,10 +21,17 @@ const onGameSpaceClick = event => {
   const gameSpaceIndex = event.target.getAttribute('data-cell-index')
   const gameSpaceDiv = $(`[data-cell-index="${gameSpaceIndex}"]`, '.game-board-container')
   if (!store.players.includes(gameSpaceDiv.text().toLowerCase())) {
-    store.user.game.cells[gameSpaceIndex] = store.players[store.currentPlayerIndex]
+    // to avoid confusion about what is currently stored in
+    // store.currentPlayerIndex, use variables currentPlayerIndex and
+    // currentPlayer
+    const currentPlayerIndex = store.currentPlayerIndex
+    const currentPlayer = store.players[currentPlayerIndex]
+    store.user.game.cells[gameSpaceIndex] = currentPlayer
     const winner = gameBoard.isGameOver(store.user.game.cells)
-    gameApi.gameSpaceClick(gameSpaceIndex, winner)
-      .then(response => gameUi.onGameSpaceClickSuccess(gameSpaceDiv, winner, response))
+    gameApi.gameSpaceClick(gameSpaceIndex, currentPlayer, winner)
+      // store.user.game has already been updated to check for winner, so
+      // response is not actually needed for anything
+      .then(response => gameUi.onGameSpaceClickSuccess(gameSpaceDiv, currentPlayer, currentPlayerIndex, winner))
       .catch(gameUi.onGameSpaceClickFailure)
   } else {
     gameUi.onGameSpaceClickFailure()

--- a/assets/scripts/game/gameUi.js
+++ b/assets/scripts/game/gameUi.js
@@ -5,6 +5,7 @@ const styleVariables = require('../../styles/variables.scss')
 
 const onGameBoardCreateSuccess = response => {
   store.user.game = response.game
+  store.currentPlayerIndex = 0
   $('.main-message').text('')
   $('.game-space')
     .text('_')
@@ -21,10 +22,9 @@ const onGameSpaceClickFailure = () => {
   $('.main-message').text(`Only click empty spaces!`)
 }
 
-const onGameSpaceClickSuccess = (gameSpaceDiv, winner, response) => {
-  gameSpaceDiv.text(store.players[store.currentPlayerIndex].toUpperCase())
+const onGameSpaceClickSuccess = (gameSpaceDiv, currentPlayer, currentPlayerIndex, winner) => {
+  gameSpaceDiv.text(currentPlayer.toUpperCase())
     .css('color', styleVariables.defaultfontcolor)
-  store.currentPlayerIndex = Math.abs(store.currentPlayerIndex - 1)
   if (winner) {
     $('.game-space').off('click')
     if (store.players.includes(winner)) {
@@ -33,9 +33,11 @@ const onGameSpaceClickSuccess = (gameSpaceDiv, winner, response) => {
       $('.main-message').text('It\'s a draw!')
     }
   } else {
+    const newPlayerIndex = Math.abs(currentPlayerIndex - 1)
+    store.currentPlayerIndex = newPlayerIndex
     $('.main-message').text('')
     $('.current-turn-container').text('Current turn: ' +
-    store.players[store.currentPlayerIndex].toUpperCase())
+    store.players[newPlayerIndex].toUpperCase())
   }
 }
 


### PR DESCRIPTION
Create new variables to avoid ambiguity over 'current player' in store
while in the middle of an event that, among other things, needs to
update the current player
Relocate the code that actually updates current player to only happen
when a game is not over (seems to clear up the occasional buggy
behavior with current player updating)